### PR TITLE
[iOS] Fix manual framework install + standard IronSource CocoaPods install

### DIFF
--- a/ios/RNIronSource.xcodeproj/project.pbxproj
+++ b/ios/RNIronSource.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 58B511D21A9E6C8500147676;
@@ -234,13 +235,14 @@
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"~/Documents/IronSourceSDK",
-					"$(PROJECT_DIR)/../../../ios/Frameworks",
+					"$(PROJECT_DIR)/../../../../ios/Frameworks/**",
+					"$(PROJECT_DIR)/../../../../ios/Pods/IronSourceSDK/IronSource",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)/../../react-native/React/**",
-					"$(SRCROOT)/../../react-native/ReactCommon/**",
+					"$(PROJECT_DIR)/../../../react-native/React/**",
+					"$(PROJECT_DIR)/../../../react-native/ReactCommon/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
@@ -254,13 +256,14 @@
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"~/Documents/IronSourceSDK",
-					"$(PROJECT_DIR)/../../../ios/Frameworks",
+					"$(PROJECT_DIR)/../../../../ios/Frameworks/**",
+					"$(PROJECT_DIR)/../../../../ios/Pods/IronSourceSDK/IronSource",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)/../../react-native/React/**",
-					"$(SRCROOT)/../../react-native/ReactCommon/**",
+					"$(PROJECT_DIR)/../../../react-native/React/**",
+					"$(PROJECT_DIR)/../../../react-native/ReactCommon/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
This fixes build errors that occur in the following scenarios:

1. A user integrates `IronSource.framework` manually, in `~/Documents/IronSourceSDK` or `ios/Frameworks` (newly supported in this PR)
2. A user integrates IronSource via CocoaPods by following the regular CocoaPods instructions in IronSource's docs

Also fixes the header search path for finding `RCTUtils.h`. It was broken when this package was published as scoped under `@wowmaking/react-native-iron-source`, as `npm` structures the directory in `node_modules` one level deeper.

All changes are backward compatible.

Fixes #3.