### PR TITLE
Remove availability call in rewarded init that causes ANR

### DIFF
--- a/android/src/main/java/co/squaretwo/ironsource/RNIronSourceRewardedVideoModule.java
+++ b/android/src/main/java/co/squaretwo/ironsource/RNIronSourceRewardedVideoModule.java
@@ -108,11 +108,6 @@ public class RNIronSourceRewardedVideoModule extends ReactContextBaseJavaModule 
                     sendEvent("ironSourceRewardedVideoAdEnded", null);
                 }
             });
-
-            boolean available = IronSource.isRewardedVideoAvailable();
-            if (available) {
-                sendEvent("ironSourceRewardedVideoAvailable", null);
-            }
         }
     }
 


### PR DESCRIPTION
This change which was added in a recent version occasionally causes the following deadlock ANR. It also simply isn't necessary, as the user of this library should assume `isRewardedVideoAvailable = false` on init, and IronSource SDK will always call the callback if that changes.

EDIT: I've also confirmed with the IronSource team that the current behavior is incorrect usage of the SDK, as there hasn't been any chance for demand to fill yet.

```
"main" prio=5 tid=1 Blocked
  | group="main" sCount=1 dsCount=0 flags=1 obj=0x72bfce30 self=0x7f2a2c7a00
  | sysTid=27315 nice=-4 cgrp=default sched=0/0 handle=0x7f2ee7c9b0
  | state=S schedstat=( 0 0 0 ) utm=79 stm=15 core=3 HZ=100
  | stack=0x7fd4fb4000-0x7fd4fb6000 stackSize=8MB
  | held mutexes=
  at com.ironsource.mediationsdk.events.RewardedVideoEventsManager.getInstance(RewardedVideoEventsManager.java:-1)
  - waiting to lock <0x027e915c> (a java.lang.Class<com.ironsource.mediationsdk.events.RewardedVideoEventsManager>) held by thread 39
  at com.ironsource.mediationsdk.IronSourceObject.prepareEventManagers(IronSourceObject.java:853)
  at com.ironsource.mediationsdk.IronSourceObject.init(IronSourceObject.java:234)
  - locked <0x09561c65> (a com.ironsource.mediationsdk.IronSourceObject)
  at com.ironsource.mediationsdk.IronSource.init(IronSource.java:76)
  at com.ironsource.mediationsdk.IronSource.init(IronSource.java:65)
  at co.squaretwo.ironsource.RNIronSourceModule$1.run(RNIronSourceModule.java:40)
  at android.os.Handler.handleCallback(Handler.java:789)
  at android.os.Handler.dispatchMessage(Handler.java:98)
  at android.os.Looper.loop(Looper.java:164)
  at android.app.ActivityThread.main(ActivityThread.java:6710)
  at java.lang.reflect.Method.invoke(Native method)
  at com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:240)
  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:770)

"mqt_native_modules" prio=5 tid=57 Blocked
  | group="main" sCount=1 dsCount=0 flags=1 obj=0x138db340 self=0x7f0c72dc00
  | sysTid=31069 nice=0 cgrp=default sched=0/0 handle=0x7f023f24f0
  | state=S schedstat=( 0 0 0 ) utm=166 stm=7 core=2 HZ=100
  | stack=0x7f022f0000-0x7f022f2000 stackSize=1037KB
  | held mutexes=
  at com.ironsource.mediationsdk.IronSourceObject.getSessionId(IronSourceObject.java:-1)
  - waiting to lock <0x02078dab> (a com.ironsource.mediationsdk.IronSourceObject) held by thread 1
  at com.ironsource.mediationsdk.events.BaseEventsManager.initState(BaseEventsManager.java:101)
  at com.ironsource.mediationsdk.events.RewardedVideoEventsManager.getInstance(RewardedVideoEventsManager.java:32)
  - locked <0x031183fa> (a java.lang.Class<com.ironsource.mediationsdk.events.RewardedVideoEventsManager>)
  at com.ironsource.mediationsdk.IronSourceObject.isRewardedVideoAvailable(IronSourceObject.java:1287)
  at com.ironsource.mediationsdk.IronSource.isRewardedVideoAvailable(IronSource.java:260)
  at co.squaretwo.ironsource.RNIronSourceRewardedVideoModule.initializeRewardedVideo(RNIronSourceRewardedVideoModule.java:112)
  at java.lang.reflect.Method.invoke(Native method)
  at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
  at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:158)
  at com.facebook.react.bridge.queue.NativeRunnable.run(Native method)
  at android.os.Handler.handleCallback(Handler.java:789)
  at android.os.Handler.dispatchMessage(Handler.java:98)
  at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:29)
  at android.os.Looper.loop(Looper.java:164)
  at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:232)
  at java.lang.Thread.run(Thread.java:764)
```