### PR TITLE
support android X build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,4 +28,5 @@ repositories {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation 'com.ironsource.sdk:mediationsdk:6.+'
+    implementation 'androidx.annotation:annotation:+'
 }

--- a/android/src/main/java/co/squaretwo/ironsource/RNIronSourceBannerModule.java
+++ b/android/src/main/java/co/squaretwo/ironsource/RNIronSourceBannerModule.java
@@ -1,7 +1,7 @@
 package co.squaretwo.ironsource;
 
 import android.app.Activity;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import android.util.DisplayMetrics;
 import android.view.Gravity;
 import android.view.View;

--- a/android/src/main/java/co/squaretwo/ironsource/RNIronSourceInterstitialsModule.java
+++ b/android/src/main/java/co/squaretwo/ironsource/RNIronSourceInterstitialsModule.java
@@ -3,7 +3,7 @@ package co.squaretwo.ironsource;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.WritableMap;

--- a/android/src/main/java/co/squaretwo/ironsource/RNIronSourceOfferwallModule.java
+++ b/android/src/main/java/co/squaretwo/ironsource/RNIronSourceOfferwallModule.java
@@ -3,7 +3,7 @@ package co.squaretwo.ironsource;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.ReactApplicationContext;

--- a/android/src/main/java/co/squaretwo/ironsource/RNIronSourceRewardedVideoModule.java
+++ b/android/src/main/java/co/squaretwo/ironsource/RNIronSourceRewardedVideoModule.java
@@ -3,7 +3,7 @@ package co.squaretwo.ironsource;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;


### PR DESCRIPTION
Fix for the issue below when build on React Native >60:

![Screen Shot 2019-10-14 at 4 47 22 PM](https://user-images.githubusercontent.com/2727930/66742725-7fef1b80-eea2-11e9-9b65-0581c94df9b0.png)


```
> Task :@wowmaking_react-native-iron-source:compileReleaseJavaWithJavac FAILED
/Volumes/Data/Projects/Trivia-app/node_modules/@wowmaking/react-native-iron-source/android/src/main/java/co/squaretwo/ironsource/RNIronSourceRewardedVideoModule.java:6: error: package an
droid.support.annotation does not exist
import android.support.annotation.Nullable;
                                 ^
/Volumes/Data/Projects/Trivia-app/node_modules/@wowmaking/react-native-iron-source/android/src/main/java/co/squaretwo/ironsource/RNIronSourceInterstitialsModule.java:6: error: package android.support.annotation does not exist
import android.support.annotation.Nullable;
                                 ^
/Volumes/Data/Projects/Trivia-app/node_modules/@wowmaking/react-native-iron-source/android/src/main/java/co/squaretwo/ironsource/RNIronSourceBannerModule.java:4: error: package android.support.annotation does not exist
import android.support.annotation.Nullable;
                                 ^
/Volumes/Data/Projects/Trivia-app/node_modules/@wowmaking/react-native-iron-source/android/src/main/java/co/squaretwo/ironsource/RNIronSourceOfferwallModule.java:6: error: package android.support.annotation does not exist
import android.support.annotation.Nullable;
                                 ^
/Volumes/Data/Projects/Trivia-app/node_modules/@wowmaking/react-native-iron-source/android/src/main/java/co/squaretwo/ironsource/RNIronSourceRewardedVideoModule.java:136: error: cannot find symbol
    private void sendEvent(String eventName, @Nullable WritableMap params) {
                                              ^
  symbol:   class Nullable
  location: class RNIronSourceRewardedVideoModule
/Volumes/Data/Projects/Trivia-app/node_modules/@wowmaking/react-native-iron-source/android/src/main/java/co/squaretwo/ironsource/RNIronSourceInterstitialsModule.java:95: error: cannot find symbol
    private void sendEvent(String eventName, @Nullable WritableMap params) {
                                              ^
  symbol:   class Nullable
  location: class RNIronSourceInterstitialsModule
/Volumes/Data/Projects/Trivia-app/node_modules/@wowmaking/react-native-iron-source/android/src/main/java/co/squaretwo/ironsource/RNIronSourceBannerModule.java:266: error: cannot find symbol
    private void sendEvent(String eventName, @Nullable WritableMap params) {
                                              ^
  symbol:   class Nullable
  location: class RNIronSourceBannerModule
/Volumes/Data/Projects/Trivia-app/node_modules/@wowmaking/react-native-iron-source/android/src/main/java/co/squaretwo/ironsource/RNIronSourceOfferwallModule.java:133: error: cannot find symbol
    private void sendEvent(String eventName, @Nullable WritableMap params) {
                                              ^
  symbol:   class Nullable
  location: class RNIronSourceOfferwallModule
Note: /Volumes/Data/Projects/Trivia-app/node_modules/@wowmaking/react-native-iron-source/android/src/main/java/co/squaretwo/ironsource/RNIronSourceBannerModule.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
8 errors
```