### PR TITLE
Add 250ms timeout to close callback to fix UnityAds edge case

### DIFF
--- a/RNIronSourceRewardedVideo.js
+++ b/RNIronSourceRewardedVideo.js
@@ -32,7 +32,7 @@ const addEventListener = (type, handler) => {
         // This is a dirty hack that is required by some Ad Networks (Vungle, UnityAds)
         // It makes 'ironSourceRewardedVideoClosedByUser' and 'ironSourceRewardedVideoAdRewarded'
         // events order match with all other networks
-        setTimeout(handler);
+        setTimeout(handler, 250);
       }));
       break;
     default:


### PR DESCRIPTION
Users in production were reporting that UnityAds were occasionally not giving rewards. I was able to reproduce and see that the "reward" callback would occasionally come a few milliseconds after the "close" callback. Adding a 250ms to the existing setTimeout in the "close" callback appears to have fixed the issue in production, and doesn't cause any negative effects for other networks.