### PR TITLE
updated: version of IronSource SDK to 7.x from 6.x

### DIFF
--- a/RNIronSource.podspec
+++ b/RNIronSource.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.default_subspec = 'Core'
 
   s.dependency "React"
-  s.dependency "IronSourceSDK", "~> 6"
+  s.dependency "IronSourceSDK", "~> 7"
 
   s.subspec "Core" do |ss|
     ss.source_files  = "ios/**/*.{h,m}"


### PR DESCRIPTION
Apple will deprecate UIWebView, developers should remove a reference of
UIWebView.