### PR TITLE
Fix : maven url to not use old/forbidden dlbintray url

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Add `SKAdNetworkIdentifier` to your Info.plist
          // Existing repos here
          // ...
          
-         maven { url "https://dl.bintray.com/ironsource-mobile/android-sdk" }
+         maven { url "https://android-sdk.is.com/" }
      }
  }
  ```
@@ -122,7 +122,7 @@ Add `SKAdNetworkIdentifier` to your Info.plist
   Add a repo to your `app/build.gradle` file 
   ```
   repositories {
-      maven { url "https://dl.bintray.com/ironsource-mobile/android-sdk" }
+      maven { url "https://android-sdk.is.com/" }
   }
   ```
 </details>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,13 +21,13 @@ android {
 
 repositories {
     maven {
-        url "https://dl.bintray.com/ironsource-mobile/android-sdk"
+        url "https://android-sdk.is.com/"
     }
 }
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.ironsource.sdk:mediationsdk:7.+'
+    implementation 'com.ironsource.sdk:mediationsdk:7.1.10'
     implementation 'androidx.annotation:annotation:+'
     implementation 'com.google.android.gms:play-services-ads-identifier:17.0.0'
     implementation 'com.google.android.gms:play-services-basement:17.1.1'


### PR DESCRIPTION
After the [shut down of Bintray,](https://www.infoq.com/news/2021/02/jfrog-jcenter-bintray-closure/) the url for the sdk now gives a forbidden error. 

This PR updates the url to a working sdk url as [mentioned here](https://developers.is.com/ironsource-mobile/android/android-sdk/#step-1).