### PR TITLE
Update IronSourceSDK version

### DIFF
--- a/RNIronSource.podspec
+++ b/RNIronSource.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.default_subspec = 'Core'
 
   s.dependency "React"
-  s.dependency "IronSourceSDK", ">= 7.0.3"
+  s.dependency "IronSourceSDK", "7.1.13"
 
   s.subspec "Core" do |ss|
     ss.source_files  = "ios/**/*.{h,m}"


### PR DESCRIPTION
In iOS 15, the app crashes when I touch the download dialog of app store.

It would be appreciated if you upload the version after confirming that there is no problem.