### PR TITLE
IronSource SDK url is changed.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,7 @@ android {
 
 repositories {
     maven {
-        url "https://dl.bintray.com/ironsource-mobile/android-sdk"
+        url "https://android-sdk.is.com/"
     }
 }
 


### PR DESCRIPTION
Fixed the deprecated SDK maven.url